### PR TITLE
Urgent problem! Unexpected end of JSON!

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@angular-devkit/core": "github:angular/angular-devkit-core-builds#d3d4336",
     "@ngtools/webpack": "github:angular/ngtools-webpack-builds#d3d4336",
     "ajv": "6.5.3",
-    "autoprefixer": "9.1.5",
+    "autoprefixer": "9.3.1",
     "circular-dependency-plugin": "5.0.2",
     "clean-css": "4.2.1",
     "copy-webpack-plugin": "4.5.4",


### PR DESCRIPTION
now npm install any angular latest project all throw error!
`npm ERR! Unexpected end of JSON input while parsing near '...^0.7.1","split":"^1.0'`
I found autoprefixer@9.1.5 dep caniuse-lite@^1.0.30000884
And build-angular@latest dep autoprefixer@9.1.5!
so please update this version and publish to npm! Hurry up! Please...