### PR TITLE
addAssets bug fix

### DIFF
--- a/src/tools/esbuild/bundler-execution-result.js
+++ b/src/tools/esbuild/bundler-execution-result.js
@@ -31,7 +31,7 @@ class ExecutionResult {
         this.outputFiles.push((0, utils_1.createOutputFileFromText)(path, content, type));
     }
     addAssets(assets) {
-        this.assetFiles.push(...assets);
+        this.assetFiles = this.assetFiles.concat(assets);
     }
     addLog(value) {
         this.logs.push(value);


### PR DESCRIPTION
There is an error message "Maximum call stack size exceeded" when the number of assets files is too large.